### PR TITLE
Get rid of mouse look option

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 public static class Config
 {
     public static bool EnableSnapTurning = true;
-    public static bool EnableMouseLook = false;
     public static bool EnableSeamoth = false;
     public static bool EnablePrawn = false;
     public static int SnapAngleChoiceIndex = 0;
@@ -17,7 +16,6 @@ public static class Config
     public static void Load()
     {
         EnableSnapTurning = PlayerPrefsExtra.GetBool(Options.PLAYER_PREF_KEY_TOGGLE_SNAP_TURNING, true);
-        EnableMouseLook = PlayerPrefsExtra.GetBool(Options.PLAYER_PREF_KEY_TOGGLE_MOUSE, false);
         EnableSeamoth = PlayerPrefsExtra.GetBool(Options.PLAYER_PREF_KEY_TOGGLE_SEAMOTH, false);
         EnablePrawn = PlayerPrefsExtra.GetBool(Options.PLAYER_PREF_KEY_TOGGLE_PRAWN, false);
         SnapAngleChoiceIndex = GetSnapAngleChoiceIndex(SnapType.Default);

--- a/MainCameraControlPatcher.cs
+++ b/MainCameraControlPatcher.cs
@@ -38,7 +38,7 @@ namespace SubnauticaSnapTurningMod
                 return false; //Don't enter vanilla method if we snap turn
             }
 
-            return Config.EnableMouseLook; //Enter vanilla method if mouse look is enabled
+            return true;
         }
 
         private static void UpdatePlayerOrVehicleRotation(bool didLookRight, bool didLookLeft)

--- a/Options.cs
+++ b/Options.cs
@@ -5,12 +5,10 @@ using UnityEngine;
 public class Options : ModOptions
 {
     public const string PLAYER_PREF_KEY_TOGGLE_SNAP_TURNING = "SnapTurningTogglePlayerPrefKey";
-    public const string PLAYER_PREF_KEY_TOGGLE_MOUSE = "SnapTurningToggleDisableMouseKey";
     public const string PLAYER_PREF_KEY_TOGGLE_SEAMOTH = "SnapTurningToggleSeamoth";
     public const string PLAYER_PREF_KEY_TOGGLE_PRAWN = "SnapTurningTogglePrawn";
     public const string PLAYER_PREF_KEY_SNAP_ANGLE = "SnapAnglePlayerPrefKey";
     private const string TOGGLE_CHANGED_ID_SNAP_TURNING = "SnapTurningId";
-    private const string TOGGLE_CHANGED_ID_ENABLE_MOUSE = "DisableMouseId";
     private const string TOGGLE_CHANGED_ID_SEAMOTH = "SeamothId";
     private const string TOGGLE_CHANGED_ID_PRAWN = "PrawnId";
     private const string CHOICE_CHANGED_ID_SNAP_ANGLE = "SnapAngleId";
@@ -31,10 +29,6 @@ public class Options : ModOptions
             case TOGGLE_CHANGED_ID_SNAP_TURNING:
                 Config.EnableSnapTurning = e.Value;
                 PlayerPrefsExtra.SetBool(PLAYER_PREF_KEY_TOGGLE_SNAP_TURNING, e.Value);
-                break;
-            case TOGGLE_CHANGED_ID_ENABLE_MOUSE:
-                Config.EnableMouseLook = e.Value;
-                PlayerPrefsExtra.SetBool(PLAYER_PREF_KEY_TOGGLE_MOUSE, e.Value);
                 break;
             case TOGGLE_CHANGED_ID_SEAMOTH:
                 Config.EnableSeamoth = e.Value;
@@ -89,7 +83,6 @@ public class Options : ModOptions
         {
             AddKeybindOption("exampleKeybindLeft", "Keyboard Left", GameInput.Device.Keyboard, Config.KeybindKeyLeft);
             AddKeybindOption("exampleKeybindRight", "Keyboard Right", GameInput.Device.Keyboard, Config.KeybindKeyRight);
-            AddToggleOption(TOGGLE_CHANGED_ID_ENABLE_MOUSE, "Mouse Look", Config.EnableMouseLook);
         }
 
         AddToggleOption(TOGGLE_CHANGED_ID_SEAMOTH, "Seamoth", Config.EnableSeamoth);


### PR DESCRIPTION
Having 'Enable Mouse Look' option disabled was causing a bug where if you tried to turn your body IRL, you would see your VR body. This gets rid of the option all together, since few people probably use it and I can't think of a way to make it work in the mean time